### PR TITLE
fix_bug_get_localtion

### DIFF
--- a/lib/assets/javascripts/turbolinks.js
+++ b/lib/assets/javascripts/turbolinks.js
@@ -327,7 +327,7 @@ Copyright © 2018 Basecamp, LLC
                         return this.initialRestorationIdentifier
                       }
                     }, r.prototype.poppedToInitialEntry = function(event) {
-                       return !event.state && event.Location.wrap(window.location) == this.initialLocation
+                       return !event.state && e.Location.wrap(window.location).isEqualTo(this.initialLocation)
                     }, r.prototype.update = function(t, e, r) {
                         var n;
                         return n = {


### PR DESCRIPTION
## What
có 2 lỗi:
1. get location:
code js gốc: https://github.com/turbolinks/turbolinks/pull/495/files#diff-449ccd5695c563ee67972dce4b5190687f33bfd21d71f3c634bdd5bffc4622feR56
```
const location = Location.currentLocation
```
thì code gem tương đương là: https://github.com/enfit-2022/turbolinks-source-gem/pull/1/commits/51b8477170de32af484255d47aaabc2d7ba5c786#diff-eec0324f07e394eed837bca841d6537ed4486467e820b583814df2750901addeL309
```
r = e.Location.wrap(window.location)
```
=> cần sửa lại là e, chứ không phải event

2. compare location
class Location có method `_isEqualTo_`, nên sửa lại dùng đúng method
https://github.com/enfit-2022/turbolinks-source-gem/blob/master/lib/assets/javascripts/turbolinks.js#L107

## Evident
![Screenshot from 2022-08-05 11-08-15](https://user-images.githubusercontent.com/106643254/183000330-608ee033-b64b-4ac1-871e-4f91cc206dec.png)

